### PR TITLE
Edit command launches VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "C#: todo Debug",
+      "type": "dotnet",
+      "request": "launch",
+      "projectPath": "${workspaceFolder}/src/todo/todo.csproj"
+    }
+  ]
+}

--- a/Help.md
+++ b/Help.md
@@ -77,6 +77,13 @@ Marks task(s) on line ITEM# as done in todo.txt.
 todo do ITEM#[, ITEM#, ITEM#, ...]
 ```
 
+### `edit`
+Opens the folder containing the todo.txt file in VS Code.
+
+```shell
+todo edit
+```
+
 ### `help`
 Display help about usage, options, built-in and add-on actions, or just the usage
 help for the passed ACTION(s).

--- a/Readme.md
+++ b/Readme.md
@@ -7,9 +7,13 @@ remain faithful to the command line and functionality of the original shell scri
 possible. As such, the [usage](#usage) below is a modified copy of the
 [original on GitHub](https://github.com/todotxt/todo.txt-cli/blob/master/USAGE.md).
 
-- [Installation](#installation)
-- [Usage](#usage)
-- [Configuration](#configuration)
+- [Dotnet Todo.txt CLI](#dotnet-todotxt-cli)
+  - [Installation](#installation)
+    - [Enabling Tab Completion](#enabling-tab-completion)
+  - [Usage](#usage)
+    - [Commands](#commands)
+    - [Warning](#warning)
+  - [Configuration](#configuration)
 
 ## Installation
 
@@ -40,6 +44,27 @@ For a complete list of options,
 ```sh
 todo --help
 ```
+
+### Commands
+
+- **add**: Adds a task to your todo.txt file.
+- **addm**: Adds multiple tasks to your todo.txt file.
+- **addto**: Adds a line of text to any file located in the todo.txt directory.
+- **append**: Adds text to the end of a task.
+- **archive**: Moves all done tasks from todo.txt to done.txt and removes blank lines.
+- **delete**: Deletes a task or a term from a task.
+- **depri**: Deprioritizes (removes the priority) from tasks.
+- **edit**: Opens the folder containing the todo.txt file in VS Code.
+- **do**: Marks tasks as done in todo.txt.
+- **list**: Displays tasks that match terms sorted by priority.
+- **listall**: Displays all tasks in todo.txt and done.txt that match terms.
+- **listcon**: Lists all task contexts starting with @.
+- **listfile**: Displays tasks from a specific file that match terms.
+- **listpri**: Displays prioritized tasks that match terms.
+- **listproj**: Lists all projects starting with +.
+- **prepend**: Adds text to the beginning of a task.
+- **pri**: Adds or updates the priority of a task.
+- **replace**: Replaces a task with updated text.
 
 ### Warning
 

--- a/src/todo.application/Commands/EditTodoCommand.cs
+++ b/src/todo.application/Commands/EditTodoCommand.cs
@@ -1,0 +1,42 @@
+using Alteridem.Todo.Domain.Interfaces;
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Alteridem.Todo.Application.Commands
+{
+    public class EditTodoCommand : IRequest<Unit>
+    {
+        // No parameters for this command
+    }
+
+    public class EditTodoCommandHandler : IRequestHandler<EditTodoCommand, Unit>
+    {
+        private readonly ITaskConfiguration _configuration;
+
+        public EditTodoCommandHandler(ITaskConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public Task<Unit> Handle(EditTodoCommand request, CancellationToken cancellationToken)
+        {
+            // Step 1: Get the directory that contains todo.txt from the configuration
+            var todoDirectory = _configuration.TodoDirectory;
+
+            // Step 2: Launch a process 'code' with the todoDirectory as a parameter
+            var processStartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "code",
+                Arguments = $"\"{todoDirectory}\"",
+                UseShellExecute = true,
+                CreateNoWindow = true,
+                WorkingDirectory = $"\"{todoDirectory}\"",
+            };
+            System.Diagnostics.Process.Start(processStartInfo);
+
+            // Stub implementation for editing logic
+            return Task.FromResult(Unit.Value);
+        }
+    }
+}

--- a/src/todo.application/todo.application.csproj
+++ b/src/todo.application/todo.application.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Todo.Application</AssemblyName>
     <RootNamespace>Alteridem.Todo.Application</RootNamespace>
     <Company>Alteridem Consulting</Company>
     <Product>Todo.txt command line utility application library</Product>
-    <Copyright>Copyright (c) 2023 Rob Prouse</Copyright>
-    <LangVersion>10</LangVersion>
+    <Copyright>Copyright (c) 2025 Rob Prouse</Copyright>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <!-- Make Internals visible to the unit tests -->

--- a/src/todo.domain/todo.domain.csproj
+++ b/src/todo.domain/todo.domain.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Todo.Domain</AssemblyName>
     <RootNamespace>Alteridem.Todo.Domain</RootNamespace>
     <Company>Alteridem Consulting</Company>
     <Product>Todo.txt command line utility domain library</Product>
-    <Copyright>Copyright (c) 2023 Rob Prouse</Copyright>
-    <LangVersion>10</LangVersion>
+    <Copyright>Copyright (c) 2025 Rob Prouse</Copyright>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/todo.infrastructure/DependencyInjection.cs
+++ b/src/todo.infrastructure/DependencyInjection.cs
@@ -23,7 +23,7 @@ public static class DependencyInjection
                     var options = new JsonSerializerOptions
                     {
                         AllowTrailingCommas = true,
-                        IgnoreNullValues = true,
+                        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                         ReadCommentHandling = JsonCommentHandling.Skip,
                         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                         WriteIndented = true

--- a/src/todo.infrastructure/todo.infrastructure.csproj
+++ b/src/todo.infrastructure/todo.infrastructure.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Todo.Infrastructure</AssemblyName>
     <RootNamespace>Alteridem.Todo.Infrastructure</RootNamespace>
     <Company>Alteridem Consulting</Company>
     <Product>Todo.txt command line utility infrastructure library</Product>
-    <Copyright>Copyright (c) 2023 Rob Prouse</Copyright>
-    <LangVersion>10</LangVersion>
+    <Copyright>Copyright (c) 2025 Rob Prouse</Copyright>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/todo/Program.cs
+++ b/src/todo/Program.cs
@@ -2,7 +2,7 @@ namespace Alteridem.Todo;
 
 class Program
 {
-    static void Main()
+    static void Main(string[] args)
     {
         var app = new TodoApplication();
         app.Run();

--- a/src/todo/Properties/launchSettings.json
+++ b/src/todo/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "todo": {
       "commandName": "Project",
-      "commandLineArgs": "ls"
+      "commandLineArgs": "edit"
     }
   }
 }

--- a/src/todo/TodoApplication.cs
+++ b/src/todo/TodoApplication.cs
@@ -305,6 +305,12 @@ public class TodoApplication
         }
     }
 
+    private async Task Edit()
+    {
+        // TODO: Implement logic to open the folder containing the todo.txt file in VS Code
+        Console.WriteLine("Opening folder in VS Code...");
+    }
+
     private RootCommand CreateCommands()
     {
         var add = new Command("add", "Adds THING I NEED TO DO to your todo.txt file on its own line.");
@@ -367,6 +373,13 @@ public class TodoApplication
         {
             Configure(d);
             await Deprioritize(items);
+        });
+
+        var edit = new Command("edit", "Opens the folder containing the todo.txt file in VS Code.");
+        edit.Handler = CommandHandler.Create(async (string d) =>
+        {
+            Configure(d);
+            await Edit();
         });
 
         var @do = new Command("do", "Marks task(s) on line ITEM# as done in todo.txt.");
@@ -471,6 +484,7 @@ public class TodoApplication
             archive,
             delete,
             depri,
+            edit,
             @do,
             list,
             listall,

--- a/src/todo/TodoApplication.cs
+++ b/src/todo/TodoApplication.cs
@@ -307,8 +307,9 @@ public class TodoApplication
 
     private async Task Edit()
     {
-        // TODO: Implement logic to open the folder containing the todo.txt file in VS Code
-        Console.WriteLine("Opening folder in VS Code...");
+        Console.WriteLine("Opening todo.txt in VS Code...");
+        var command = new EditTodoCommand();
+        await Mediator.Send(command);
     }
 
     private RootCommand CreateCommands()

--- a/src/todo/todo.csproj
+++ b/src/todo/todo.csproj
@@ -8,18 +8,19 @@
     <Authors>Rob Prouse</Authors>
     <Company>Alteridem Consulting</Company>
     <Product>Todo.txt command line utility</Product>
-    <Copyright>Copyright (c) 2024 Rob Prouse</Copyright>
+    <Copyright>Copyright (c) 2025 Rob Prouse</Copyright>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/rprouse/dotnet-todo</PackageProjectUrl>
     <RepositoryUrl>https://github.com/rprouse/dotnet-todo</RepositoryUrl>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageId>dotnet-todo</PackageId>
-    <Version>0.6.4</Version>
+    <Version>0.7.0</Version>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>todo</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <RepositoryType>git</RepositoryType>
     <Description>dotnet-todo is a .NET command line port of http://todotxt.org/ that tries to remain faithful to the command line and functionality of the original shell script wherever possible.</Description>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/todo.tests/todo.tests.csproj
+++ b/tests/todo.tests/todo.tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Alteridem.Todo.Tests</RootNamespace>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an "edit" command to open the folder containing the todo.txt file in Visual Studio Code directly from the CLI.

- **Documentation**
  - Updated help and README documentation to include the new "edit" command and reorganized content for better clarity.

- **Chores**
  - Upgraded projects to target .NET 8.0 and C# 12.
  - Updated copyright years.
  - Incremented version to 0.7.0.

- **Style**
  - Improved JSON serialization settings for better compatibility.

- **Tests**
  - Set test project to use C# 12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->